### PR TITLE
Remove redundant conditional statement.

### DIFF
--- a/player.cc
+++ b/player.cc
@@ -438,7 +438,6 @@ std::optional<std::tuple<int, std::optional<Move>>> AlphaBetaPlayer::Search(
       && move_count >= 4
       && (move.IsCapture() || quiets >= 2)
       && !is_pv_node
-      && move_count > (is_pv_node && ply <= 1)
       && (!is_tt_pv
           || !move.IsCapture()
           || (is_cut_node && (ss-1)->move_count > 1))


### PR DESCRIPTION
Fixes `player.cc(441): warning C4804: '>': unsafe use of type 'bool' in operation`.
No point in checking `move_count > (is_pv_node && ply <= 1)` if you already have `move_count >= 4`.