### PR TITLE
Fix warnings and improve parallel search code

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,7 +23,7 @@ nohup*
 api_key*.txt
 __pycache__*
 
-.vs
+.vs*
 d2
 d3
 d4
@@ -34,3 +34,4 @@ nnue
 cli
 MODULE.bazel*
 
+code*

--- a/move_picker.cc
+++ b/move_picker.cc
@@ -45,11 +45,11 @@ MovePicker::MovePicker(
 
     int score = piece_move_order_scores[piece.GetPieceType()];
     if (pvmove.has_value() && move == *pvmove) {
-      stages_[PV_MOVE].emplace_back(i, score);
+      stages_[PV_MOVE].emplace_back(static_cast<short>(i), static_cast<float>(score));
     } else if (killers != nullptr
                && (killers[0] == move || killers[1] == move)
                && include_quiets) {
-      stages_[KILLER].emplace_back(i, score + (move == killers[0] ? 1 : 0));
+      stages_[KILLER].emplace_back(static_cast<short>(i), static_cast<float>(score + (move == killers[0] ? 1 : 0)));
     } else if (move.IsCapture()) {
       int captured_val = piece_evaluations[capture.GetPieceType()];
       int attacker_val = piece_evaluations[piece.GetPieceType()];
@@ -60,9 +60,9 @@ MovePicker::MovePicker(
         [to.GetRow()][to.GetCol()];
       score += history_score;
       if (attacker_val <= captured_val) {
-        stages_[GOOD_CAPTURE].emplace_back(i, score);
+        stages_[GOOD_CAPTURE].emplace_back(static_cast<short>(i), static_cast<float>(score));
       } else {
-        stages_[BAD_CAPTURE].emplace_back(i, score);
+        stages_[BAD_CAPTURE].emplace_back(static_cast<short>(i), static_cast<float>(score));
       }
     } else if (include_quiets) {
       score += history_heuristic[piece.GetPieceType()][from.GetRow()][from.GetCol()][to.GetRow()][to.GetCol()] / 2;
@@ -76,7 +76,7 @@ MovePicker::MovePicker(
       score += (*piece_to_history[3])[piece_type][to.GetRow()][to.GetCol()] / 4;
       score += (*piece_to_history[4])[piece_type][to.GetRow()][to.GetCol()] / 4;
 
-      stages_[QUIET].emplace_back(i, score);
+      stages_[QUIET].emplace_back(static_cast<short>(i), static_cast<float>(score));
     }
   }
 
@@ -99,7 +99,7 @@ Move* MovePicker::GetNextMove() {
       if (enable_move_order_checks_) {
         for (auto& item : stage_vec) {
           if (moves_[item.index].DeliversCheck(*board_)) {
-            item.score += stage_ == QUIET ? 100'000 : 10'00;
+            item.score += (stage_ == QUIET ? 100'000.0f : 1000.0f);
           }
         }
       }

--- a/player.h
+++ b/player.h
@@ -73,6 +73,7 @@ struct PlayerOptions {
   bool enable_late_move_reduction = true;
   bool enable_late_move_pruning =   true;
   bool enable_null_move_pruning =   true;
+  bool enable_singular_extensions = true;
 
   // for multithreading
   bool enable_multithreading = true;
@@ -85,6 +86,7 @@ struct PlayerOptions {
 
 struct Stack {
   Move killers[2];
+  Move excludedMove;
   bool tt_pv = false;
   int move_count = 0;
   // indexed by (piece_type, row, col)

--- a/player.h
+++ b/player.h
@@ -110,18 +110,18 @@ class ThreadState {
   ThreadState(
       PlayerOptions options, const Board& board, const PVInfo& pv_info);
   ~ThreadState();
-  Board& GetBoard() { return board_; }
   Move* GetNextMoveBufferPartition();
   void ReleaseMoveBufferPartition();
   int* NActivated() { return n_activated_; }
   int* TotalMoves() { return total_moves_; }
   PVInfo& GetPVInfo() { return pv_info_; }
+  const Board& GetRootBoard() { return root_board_; }
 
   int n_threats[4] = {0, 0, 0, 0};
 
  private:
   PlayerOptions options_;
-  Board board_;
+  const Board& root_board_;
   PVInfo pv_info_;
 
   // Buffer used to store moves per node.
@@ -147,7 +147,7 @@ class AlphaBetaPlayer {
       int max_depth = 20);
   int StaticEvaluation(Board& board);
   // Eval with respect to the maximizing player
-  int Evaluate(ThreadState& thread_state, bool maximizing_player,
+  int Evaluate(ThreadState& thread_state, Board& board, bool maximizing_player,
       int alpha = -kMateValue, int beta = kMateValue);
   void CancelEvaluation() { canceled_ = true; }
   // NOTE: Should wait until evaluation is done before resetting this to true.
@@ -159,6 +159,7 @@ class AlphaBetaPlayer {
       Stack* ss,
       NodeType node_type,
       ThreadState& thread_state,
+      Board& board,
       int ply,
       int depth,
       int alpha,
@@ -174,6 +175,7 @@ class AlphaBetaPlayer {
       Stack* ss,
       NodeType node_type,
       ThreadState& thread_state,
+      Board& board,
       int depth, // called initially with depth = 0, further decreases
       int alpha,
       int beta,
@@ -219,14 +221,14 @@ class AlphaBetaPlayer {
       std::optional<std::chrono::time_point<std::chrono::system_clock>> deadline,
       int max_depth = 20);
 
-  void ResetMobilityScores(ThreadState& thread_state);
+  void ResetMobilityScores(ThreadState& thread_state, Board& board);
   void ResetHistoryHeuristics();
   void AgeHistoryHeuristics();
   void UpdateStats(Stack* ss, ThreadState& thread_state, const Board& board,
                    const Move& move, int depth, bool fail_high,
                    const std::vector<Move>& searched_moves);
   void UpdateQuietStats(Stack* ss, const Move& move);
-  void UpdateMobilityEvaluation(ThreadState& thread_state, Player turn);
+  void UpdateMobilityEvaluation(ThreadState& thread_state, Board& board, Player turn);
   void UpdateContinuationHistories(Stack* ss, const Move& move, PieceType piece_type, int bonus);
   bool HasShield(Board& board, PlayerColor color, const BoardLocation& king_loc);
   bool OnBackRank(const BoardLocation& king_loc);

--- a/player.h
+++ b/player.h
@@ -45,6 +45,7 @@ struct PlayerOptions {
   bool pvs = true;
   bool enable_transposition_table = true;
   bool enable_check_extensions = true;
+  bool enable_singular_extensions = false;
   bool enable_qsearch = true;
   bool enable_aspiration_window = true;
   bool enable_probcut = true;
@@ -73,7 +74,6 @@ struct PlayerOptions {
   bool enable_late_move_reduction = true;
   bool enable_late_move_pruning =   true;
   bool enable_null_move_pruning =   true;
-  bool enable_singular_extensions = true;
 
   // for multithreading
   bool enable_multithreading = true;

--- a/player.h
+++ b/player.h
@@ -216,14 +216,15 @@ class AlphaBetaPlayer {
   void EnableDebug(bool enable) { enable_debug_ = enable; }
 
   // for debugging
-  int64_t test1_ = 0;
-  int64_t test2_ = 0;
-  int64_t test3_ = 0;
+  std::atomic<int64_t> test1_ = 0;
+  std::atomic<int64_t> test2_ = 0;
+  std::atomic<int64_t> test3_ = 0;
 
  private:
 
   std::optional<std::tuple<int, std::optional<Move>, int>>
     MakeMoveSingleThread(
+      size_t thread_id,
       ThreadState& state,
       std::optional<std::chrono::time_point<std::chrono::system_clock>> deadline,
       int max_depth = 20);
@@ -238,23 +239,23 @@ class AlphaBetaPlayer {
   bool HasShield(Board& board, PlayerColor color, const BoardLocation& king_loc);
   bool OnBackRank(const BoardLocation& king_loc);
 
-  int64_t num_nodes_ = 0; // debugging
-  int64_t num_cache_hits_ = 0;
-  int64_t num_null_moves_tried_ = 0;
-  int64_t num_null_moves_pruned_ = 0;
-  int64_t num_futility_moves_pruned_ = 0;
-  int64_t num_lmr_searches_ = 0;
-  int64_t num_lmr_researches_ = 0;
-  int64_t num_singular_extension_searches_ = 0;
-  int64_t num_singular_extensions_ = 0;
-  int64_t num_lm_pruned_ = 0;
-  int64_t num_fail_high_reductions_ = 0;
-  int64_t num_check_extensions_ = 0;
-  int64_t num_lazy_eval_ = 0;
-  int64_t num_razor_ = 0;
-  int64_t num_razor_tested_ = 0;
+  std::atomic<int64_t> num_nodes_ = 0; // debugging
+  std::atomic<int64_t> num_cache_hits_ = 0;
+  std::atomic<int64_t> num_null_moves_tried_ = 0;
+  std::atomic<int64_t> num_null_moves_pruned_ = 0;
+  std::atomic<int64_t> num_futility_moves_pruned_ = 0;
+  std::atomic<int64_t> num_lmr_searches_ = 0;
+  std::atomic<int64_t> num_lmr_researches_ = 0;
+  std::atomic<int64_t> num_singular_extension_searches_ = 0;
+  std::atomic<int64_t> num_singular_extensions_ = 0;
+  std::atomic<int64_t> num_lm_pruned_ = 0;
+  std::atomic<int64_t> num_fail_high_reductions_ = 0;
+  std::atomic<int64_t> num_check_extensions_ = 0;
+  std::atomic<int64_t> num_lazy_eval_ = 0;
+  std::atomic<int64_t> num_razor_ = 0;
+  std::atomic<int64_t> num_razor_tested_ = 0;
 
-  bool canceled_ = false;
+  std::atomic<bool> canceled_ = false;
   int piece_move_order_scores_[6];
   PlayerOptions options_;
   int location_evaluations_[14][14];

--- a/player.h
+++ b/player.h
@@ -221,6 +221,7 @@ class AlphaBetaPlayer {
 
   void ResetMobilityScores(ThreadState& thread_state);
   void ResetHistoryHeuristics();
+  void AgeHistoryHeuristics();
   void UpdateStats(Stack* ss, ThreadState& thread_state, const Board& board,
                    const Move& move, int depth, bool fail_high,
                    const std::vector<Move>& searched_moves);

--- a/transposition_table.cc
+++ b/transposition_table.cc
@@ -13,10 +13,12 @@ TranspositionTable::TranspositionTable(size_t table_size) {
   assert(
       (hash_table_ != nullptr) && 
       "Can't create transposition table. Try using a smaller size.");
+  a_mutexes_ = std::make_unique<std::mutex[]>(kNumMutexes);
 }
 
 const HashTableEntry* TranspositionTable::Get(int64_t key) {
   size_t n = key % table_size_;
+  std::lock_guard<std::mutex> lock(a_mutexes_[n % kNumMutexes]);
   HashTableEntry* entry = hash_table_ + n;
   if (entry->key == key) {
     return entry;
@@ -28,13 +30,18 @@ void TranspositionTable::Save(
     int64_t key, int depth, std::optional<Move> move, int score,
     ScoreBound bound, bool is_pv) {
   size_t n = key % table_size_;
+  std::lock_guard<std::mutex> lock(a_mutexes_[n % kNumMutexes]);
   HashTableEntry& entry = hash_table_[n];
   if (bound == EXACT
       || entry.key != key
-      || entry.depth < depth) {
+      || entry.depth <= depth) { // Prioritize entries from deeper searches
     entry.key = key;
     entry.depth = depth;
-    entry.move = move;
+    if (move.has_value()) {
+      entry.move = *move;
+    } else {
+      entry.move = Move();
+    }
     entry.score = score;
     entry.bound = bound;
     entry.is_pv = is_pv;
@@ -43,4 +50,3 @@ void TranspositionTable::Save(
 
 
 }  // namespace chess
-

--- a/transposition_table.cc
+++ b/transposition_table.cc
@@ -27,7 +27,7 @@ const HashTableEntry* TranspositionTable::Get(int64_t key) {
 }
 
 void TranspositionTable::Save(
-    int64_t key, int depth, std::optional<Move> move, int score,
+    int64_t key, int depth, std::optional<Move> move, int score, int eval,
     ScoreBound bound, bool is_pv) {
   size_t n = key % table_size_;
   std::lock_guard<std::mutex> lock(a_mutexes_[n % kNumMutexes]);
@@ -43,6 +43,7 @@ void TranspositionTable::Save(
       entry.move = Move();
     }
     entry.score = score;
+    entry.eval = eval;
     entry.bound = bound;
     entry.is_pv = is_pv;
   }

--- a/transposition_table.h
+++ b/transposition_table.h
@@ -3,6 +3,8 @@
 
 #include <atomic>
 #include <cstdint>
+#include <memory>
+#include <mutex>
 #include <optional>
 
 #include "board.h"
@@ -16,7 +18,7 @@ enum ScoreBound {
 struct HashTableEntry {
   int64_t key;
   int depth;
-  std::optional<Move> move;
+  Move move;
   int score;
   ScoreBound bound;
   bool is_pv;
@@ -39,6 +41,8 @@ class TranspositionTable {
  private:
   HashTableEntry* hash_table_ = nullptr;
   size_t table_size_ = 0;
+  static constexpr size_t kNumMutexes = 256;
+  std::unique_ptr<std::mutex[]> a_mutexes_;
 };
 
 

--- a/transposition_table.h
+++ b/transposition_table.h
@@ -11,6 +11,8 @@
 
 namespace chess {
 
+constexpr int value_none_tt = -119988;
+
 enum ScoreBound {
   EXACT = 0, LOWER_BOUND = 1, UPPER_BOUND = 2,
 };
@@ -20,6 +22,7 @@ struct HashTableEntry {
   int depth;
   Move move;
   int score;
+  int eval;
   ScoreBound bound;
   bool is_pv;
 };
@@ -30,7 +33,7 @@ class TranspositionTable {
 
    const HashTableEntry* Get(int64_t key);
    void Save(int64_t key, int depth, std::optional<Move> move,
-             int score, ScoreBound bound, bool is_pv);
+             int score, int eval, ScoreBound bound, bool is_pv);
 
   ~TranspositionTable() {
     if (hash_table_ != nullptr) {


### PR DESCRIPTION
+676.1 elo after 250 games at 800 ms/move, 6 threads each.

C:\Users\dell3\source\repos\scm\x64\Debug>scm.exe --e1 "C:\Users\dell3\source\repos5\4pchess-o\bazel-bin\cli.exe" --e2 "C:\Users\dell3\source\repos5\4pchess-1\bazel-bin\cli.exe" --fixed 800 --games 250 --threads 2 --fens FENs_4PC_balanced.txt --cores1 6 --cores2 6 --pgn4 games.pgn4 --margin 10000
simplechessmatch
loading engines...
engines loaded.

***** Press any key to exit and terminate match *****

Engine1 (C:\Users\dell3\source\repos5\4pchess-o\bazel-bin\cli.exe): 0 wins. Engine2 (C:\Users\dell3\source\repos5\4pchess-1\bazel-bin\cli.exe): 1 wins.  0 draws.  0% - 100%  elo +inf
.
.
.
Engine1 (C:\Users\dell3\source\repos5\4pchess-o\bazel-bin\cli.exe): 5 wins. Engine2 (C:\Users\dell3\source\repos5\4pchess-1\bazel-bin\cli.exe): 245 wins.  0 draws.  2% - 98%  elo +676.1
shutting down engines...
Exiting.

C:\Users\dell3\source\repos\scm\x64\Debug>
